### PR TITLE
feat(linux): run LocalText2Voice on Linux from source + EXDEV export fix

### DIFF
--- a/app/core/audio_pipeline.py
+++ b/app/core/audio_pipeline.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import difflib
 import json
+import os
 import re
+import shutil
 import tempfile
 import threading
 import time
@@ -15,6 +17,18 @@ from typing import Any, Callable
 
 from app.tts.base import BaseTTSEngine, TTSCancelled, TTSEngineError
 from app.core.audio_mix import ducking_filter
+
+
+def _move_file(src: Path, dst: Path) -> None:
+    """Move a file even across filesystems.
+
+    Path.replace()/os.replace() raise EXDEV ("Invalid cross-device link")
+    when the temp dir lives on another mount (e.g. tmpfs /tmp on Linux).
+    """
+    try:
+        os.replace(src, dst)
+    except OSError:
+        shutil.move(str(src), str(dst))
 from app.core.audiobook_store import AudiobookStore, StoredAudiobook
 from app.utils.ffmpeg_utils import (
     FFmpegCancelled,
@@ -768,7 +782,7 @@ class AudioPipeline:
         ]
         started = time.perf_counter()
         runner.run(arguments)
-        processed.replace(output_wav)
+        _move_file(processed, output_wav)
         self.log_callback(
             "LTV Markup postprocess applied in "
             f"{self._format_duration(time.perf_counter() - started)} "
@@ -1918,7 +1932,7 @@ class AudioPipeline:
             f"({self._format_file_size(temporary_mp3)})."
         )
         final_path = options.output_dir / filename
-        temporary_mp3.replace(final_path)
+        _move_file(temporary_mp3, final_path)
         self.log_callback(f"Saved: {final_path}")
         return NarrationArtifact(
             wav_path=joined_wav,
@@ -2031,7 +2045,7 @@ class AudioPipeline:
                 f"({self._format_file_size(temporary_mp3)})."
             )
             final_path = options.output_dir / filename
-            temporary_mp3.replace(final_path)
+            _move_file(temporary_mp3, final_path)
             outputs.append(
                 NarrationArtifact(
                     wav_path=joined_wav,
@@ -2291,7 +2305,7 @@ class AudioPipeline:
         )
 
         final_path = options.output_dir / artifact.podcast_filename
-        temporary_output.replace(final_path)
+        _move_file(temporary_output, final_path)
         self.log_callback(f"Saved: {final_path}")
         self.log_callback(
             f"Podcast mix completed in "

--- a/app/server/ltv_service.py
+++ b/app/server/ltv_service.py
@@ -41,7 +41,7 @@ from app.tts.voice_gallery_manager import (
     VoiceGalleryManager,
 )
 from app.tts.voice_manager import VoiceInfo, VoiceManager
-from app.utils.paths import application_root, resolve_app_path
+from app.utils.paths import application_root, resolve_app_path, resolve_executable
 from app.verification.faster_whisper_manager import (
     FasterWhisperManager,
     FasterWhisperVerifier,
@@ -493,7 +493,7 @@ class LocalText2VoiceService:
             int(review.get("beam_size", 1)),
             float(review.get("approve_threshold", 92.0)),
             int(review.get("max_retries", 0)),
-            resolve_app_path(
+            resolve_executable(
                 self.settings.get("piper_path", "engines/piper/piper.exe")
             ),
             voice_config,
@@ -690,7 +690,7 @@ class LocalText2VoiceService:
         engine_id: str,
         log_callback: LogCallback,
     ) -> BaseTTSEngine:
-        piper_path = resolve_app_path(self.settings.get("piper_path", "engines/piper/piper.exe"))
+        piper_path = resolve_executable(self.settings.get("piper_path", "engines/piper/piper.exe"))
         if not self.keep_engines_alive:
             engine = create_tts_engine(engine_id, piper_path)
             engine.set_log_callback(log_callback)
@@ -1123,7 +1123,7 @@ class LocalText2VoiceService:
 
     def _engine_installed(self, engine_id: str) -> bool | None:
         if engine_id == "piper":
-            return resolve_app_path(self.settings.get("piper_path", "engines/piper/piper.exe")).is_file()
+            return resolve_executable(self.settings.get("piper_path", "engines/piper/piper.exe")).is_file()
         if engine_id == "kokoro":
             return self.kokoro_manager.is_installed()
         if engine_id == "chatterbox":

--- a/app/tts/python_runtime_manager.py
+++ b/app/tts/python_runtime_manager.py
@@ -4,6 +4,7 @@ import json
 import os
 import shutil
 import subprocess
+import sys
 import threading
 import time
 import urllib.error
@@ -53,7 +54,18 @@ class PythonRuntimeManager:
     ) -> None:
         self.runtime_dir = (runtime_dir or self._default_runtime_dir()).resolve()
         self.python_dir = self.runtime_dir / "python"
-        self.python_exe = self.python_dir / "python.exe"
+        self._is_windows = sys.platform.startswith("win")
+        # Windows: скачиваемый embeddable-пакет (python.exe в корне).
+        # Linux/macOS: venv от системного интерпретатора (bin/python).
+        if self._is_windows:
+            self.python_exe = self.python_dir / "python.exe"
+            self.runtime_version = self.RUNTIME_VERSION
+            self.python_version = self.PYTHON_VERSION
+        else:
+            self.python_exe = self.python_dir / "bin" / "python"
+            vi = sys.version_info
+            self.python_version = f"{vi.major}.{vi.minor}.{vi.micro}"
+            self.runtime_version = f"python-{self.python_version}-venv-{sys.platform}-v1"
         self.timeout_seconds = timeout_seconds
         self._cancel_requested = threading.Event()
         self._process: subprocess.Popen[bytes] | None = None
@@ -63,7 +75,7 @@ class PythonRuntimeManager:
         manifest = self.install_manifest()
         return (
             manifest.get("state") == "installed"
-            and manifest.get("runtime_version") == self.RUNTIME_VERSION
+            and manifest.get("runtime_version") == self.runtime_version
             and self.python_exe.is_file()
             and self.pip_module_path.is_dir()
         )
@@ -82,8 +94,10 @@ class PythonRuntimeManager:
         progress = progress_callback or (lambda current, total, message: None)
         self._cancel_requested.clear()
         if self.is_installed():
-            progress(100, 100, "Embedded Python runtime already installed.")
+            progress(100, 100, "Python runtime already installed.")
             return self.runtime_dir
+        if not self._is_windows:
+            return self._install_venv(progress, cancel_token)
         downloads_dir = self.runtime_dir / ".downloads"
         staging_dir = self.runtime_dir / ".staging"
         python_zip = downloads_dir / "python-embed.zip"
@@ -159,6 +173,57 @@ class PythonRuntimeManager:
             self._remove_path(downloads_dir)
             self._remove_path(staging_dir)
 
+    def _install_venv(
+        self,
+        progress: PythonRuntimeProgress,
+        cancel_token: threading.Event | None,
+    ) -> Path:
+        """Linux/macOS: приватный рантайм = venv от системного Python.
+
+        Windows-сборка качает embeddable-пакет с python.org; на остальных
+        платформах системный интерпретатор уже есть, нужен только venv.
+        """
+        staging_python_dir = self.runtime_dir / ".staging" / "python"
+        self._remove_path(staging_python_dir.parent)
+        staging_python_dir.parent.mkdir(parents=True, exist_ok=True)
+        self._write_manifest("installing")
+        try:
+            progress(20, 100, f"Creating virtual environment (Python {self.python_version})...")
+            self._run_process(
+                [sys.executable, "-m", "venv", str(staging_python_dir)],
+                cancel_token,
+                cwd=staging_python_dir.parent,
+            )
+            staging_exe = staging_python_dir / "bin" / "python"
+            progress(60, 100, "Installing Python engine core packages...")
+            self._run_process(
+                [
+                    str(staging_exe),
+                    "-m",
+                    "pip",
+                    "install",
+                    "--no-warn-script-location",
+                    *self.CORE_PACKAGES,
+                ],
+                cancel_token,
+                cwd=staging_python_dir,
+            )
+            progress(85, 100, "Finalizing Python runtime...")
+            self._remove_path(self.python_dir)
+            self.runtime_dir.mkdir(parents=True, exist_ok=True)
+            shutil.move(str(staging_python_dir), str(self.python_dir))
+            self._write_manifest("installed")
+            progress(100, 100, "Python runtime installed.")
+            return self.runtime_dir
+        except PythonRuntimeCancelled:
+            self._write_manifest("cancelled")
+            raise
+        except Exception:
+            self._write_manifest("failed")
+            raise
+        finally:
+            self._remove_path(staging_python_dir.parent)
+
     def uninstall(self) -> None:
         self.cancel()
         self._remove_path(self.runtime_dir)
@@ -207,7 +272,12 @@ class PythonRuntimeManager:
 
     @property
     def pip_module_path(self) -> Path:
-        return self.python_dir / "Lib" / "site-packages" / "pip"
+        if self._is_windows:
+            return self.python_dir / "Lib" / "site-packages" / "pip"
+        matches = sorted(self.python_dir.glob("lib/python*/site-packages/pip"))
+        if matches:
+            return matches[0]
+        return self.python_dir / "lib" / "site-packages" / "pip"
 
     def _download_file(
         self,
@@ -350,12 +420,12 @@ class PythonRuntimeManager:
     def _write_manifest(self, state: str) -> None:
         manifest = {
             "runtime": "python",
-            "runtime_version": self.RUNTIME_VERSION,
+            "runtime_version": self.runtime_version,
             "state": state,
             "updated_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
-            "python_version": self.PYTHON_VERSION,
-            "python_url": self.PYTHON_ZIP_URL,
-            "get_pip_url": self.GET_PIP_URL,
+            "python_version": self.python_version,
+            "python_url": self.PYTHON_ZIP_URL if self._is_windows else f"venv:{sys.executable}",
+            "get_pip_url": self.GET_PIP_URL if self._is_windows else "stdlib-venv",
             "core_packages": list(self.CORE_PACKAGES),
             "python_path": str(self.python_exe),
         }

--- a/app/utils/ffmpeg_utils.py
+++ b/app/utils/ffmpeg_utils.py
@@ -22,12 +22,19 @@ def find_ffmpeg(configured_path: str | Path) -> Path:
     if configured.is_file():
         return configured
 
+    # Windows configs usually say "ffmpeg/ffmpeg.exe"; on Linux/macOS the
+    # same bundled folder would hold an extension-less binary.
+    if configured.suffix.lower() == ".exe":
+        sibling = configured.with_suffix("")
+        if sibling.is_file():
+            return sibling
+
     path_match = shutil.which("ffmpeg")
     if path_match:
         return Path(path_match)
 
     raise FFmpegError(
-        "FFmpeg was not found. Place ffmpeg.exe in the ffmpeg folder, "
+        "FFmpeg was not found. Place ffmpeg in the ffmpeg folder, "
         "set ffmpeg_path in config.json, or add FFmpeg to PATH."
     )
 

--- a/app/utils/paths.py
+++ b/app/utils/paths.py
@@ -42,3 +42,25 @@ def app_data_root() -> Path:
     if sys.platform == "darwin":
         return Path.home() / "Library" / "Application Support" / "LocalText2Voice"
     return Path(os.environ.get("XDG_DATA_HOME", Path.home() / ".local" / "share")) / "LocalText2Voice"
+
+
+def resolve_executable(value: str | Path) -> Path:
+    """Resolve a configured executable path across platforms.
+
+    Windows configs usually point at "*.exe". On Linux/macOS the same
+    bundled folder holds an extension-less binary, and a system-wide
+    installation may be available through PATH.
+    """
+    import shutil
+
+    configured = resolve_app_path(value)
+    if configured.is_file():
+        return configured
+    if configured.suffix.lower() == ".exe":
+        sibling = configured.with_suffix("")
+        if sibling.is_file():
+            return sibling
+        path_match = shutil.which(sibling.name)
+        if path_match:
+            return Path(path_match)
+    return configured

--- a/docs/LINUX.md
+++ b/docs/LINUX.md
@@ -1,0 +1,54 @@
+# LocalText2Voice on Linux
+
+The application core is cross-platform (PySide6). On Windows the installer
+bundles everything; on Linux you run from source. Tested on Arch/CachyOS
+(KDE Plasma, Wayland) with Python 3.12.
+
+## Requirements
+
+- Python 3.10+
+- `ffmpeg` available in `PATH` (`sudo pacman -S ffmpeg` / `sudo apt install ffmpeg`).
+  The bundled `ffmpeg/` folder is only needed on Windows; on Linux the app
+  finds the system binary automatically (see `app/utils/ffmpeg_utils.py`).
+- For local TTS engines: they are downloaded by the app itself
+  (Settings -> Engine management). Piper and Kokoro work on CPU;
+  Chatterbox / Qwen3 TTS / OmniVoice can use an NVIDIA GPU.
+
+## Run
+
+```bash
+./run_dev.sh          # creates .venv and installs deps on first run
+# or manually:
+python3 -m venv .venv
+.venv/bin/pip install -r requirements.txt
+QT_QPA_PLATFORM=wayland .venv/bin/python main.py   # or omit for X11
+```
+
+## Desktop integration (optional)
+
+```bash
+mkdir -p ~/.local/share/applications
+cat > ~/.local/share/applications/localtext2voice.desktop <<EOF
+[Desktop Entry]
+Type=Application
+Name=LocalText2Voice
+Exec=$(pwd)/run_dev.sh
+Icon=$(pwd)/assets/logotipo.png
+Categories=Audio;Utility;
+EOF
+```
+
+## Tests
+
+```bash
+QT_QPA_PLATFORM=offscreen .venv/bin/python -m pytest -q
+```
+
+## Known platform notes
+
+- Auto-update flow (`app/core/update_manager.py`) is Windows-only and is
+  skipped on other platforms; update with `git pull`.
+- Writable data lives in `$XDG_DATA_HOME/LocalText2Voice`
+  (`~/.local/share/LocalText2Voice`) via `app/utils/paths.py:app_data_root()`.
+- If Qt multimedia warnings about FFmpeg appear on startup, they are
+  informational - playback still uses the system FFmpeg.

--- a/run_dev.sh
+++ b/run_dev.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# LocalText2Voice - developer launcher for Linux (equivalent of run_dev.bat)
+set -euo pipefail
+cd "$(dirname "$0")"
+
+PY=python3
+VENV=.venv
+
+if [ ! -x "$VENV/bin/python" ]; then
+    echo "[lt2v] creating virtual environment..."
+    $PY -m venv "$VENV"
+    "$VENV/bin/pip" install --upgrade pip
+    "$VENV/bin/pip" install -r requirements.txt
+fi
+
+# Wayland is preferred when available, X11 works out of the box too.
+if [ -n "${WAYLAND_DISPLAY:-}" ] && [ -z "${QT_QPA_PLATFORM:-}" ]; then
+    export QT_QPA_PLATFORM=wayland
+fi
+
+exec "$VENV/bin/python" main.py "$@"

--- a/tests/test_platform_support.py
+++ b/tests/test_platform_support.py
@@ -1,0 +1,58 @@
+"""Tests for Linux/cross-platform support helpers."""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from app.core.audio_pipeline import _move_file
+from app.utils.ffmpeg_utils import find_ffmpeg
+from app.utils.paths import resolve_executable
+
+
+class TestResolveExecutable:
+    def test_configured_exe_found_as_is(self, tmp_path: Path) -> None:
+        exe = tmp_path / "tool.exe"
+        exe.write_text("bin")
+        assert resolve_executable(exe) == exe
+
+    def test_extensionless_sibling_used_on_linux(self, tmp_path: Path) -> None:
+        # Windows-style config points at tool.exe, but on Linux the bundled
+        # folder holds an extension-less binary named "tool".
+        sibling = tmp_path / "tool"
+        sibling.write_text("bin")
+        assert resolve_executable(tmp_path / "tool.exe") == sibling
+
+    def test_missing_everywhere_returns_configured(self, tmp_path: Path) -> None:
+        configured = tmp_path / "definitely-missing-tool-xyz.exe"
+        assert resolve_executable(configured) == configured
+
+
+class TestFindFFmpeg:
+    def test_extensionless_bundled_binary(self, tmp_path: Path) -> None:
+        bundled = tmp_path / "ffmpeg"
+        bundled.write_text("bin")
+        assert find_ffmpeg(tmp_path / "ffmpeg.exe") == bundled
+
+
+class TestMoveFile:
+    def test_same_filesystem(self, tmp_path: Path) -> None:
+        src = tmp_path / "a.mp3"
+        dst = tmp_path / "b.mp3"
+        src.write_bytes(b"audio")
+        _move_file(src, dst)
+        assert dst.read_bytes() == b"audio"
+        assert not src.exists()
+
+    def test_cross_device_exdev_falls_back(self, tmp_path: Path, monkeypatch) -> None:
+        """os.replace raising EXDEV (tmpfs /tmp -> ext4 home on Linux)."""
+        src = tmp_path / "a.mp3"
+        dst = tmp_path / "b.mp3"
+        src.write_bytes(b"audio")
+
+        def _raise_exdev(s, d):
+            raise OSError(18, "Invalid cross-device link")
+
+        monkeypatch.setattr(os, "replace", _raise_exdev)
+        _move_file(src, dst)
+        assert dst.read_bytes() == b"audio"
+        assert not src.exists()


### PR DESCRIPTION
## Summary

LocalText2Voice already has a mostly cross-platform core (PySide6), but it only shipped as a Windows app. This PR makes it run on Linux from source and fixes one hard crash that only manifests on Linux:

- **`run_dev.sh`** - developer launcher for Linux (venv bootstrap, Wayland auto-detection), equivalent of `run_dev.bat`
- **`docs/LINUX.md`** - requirements, run instructions, optional .desktop integration, test command
- **`app/utils/paths.py: resolve_executable()`** - cross-platform resolution of configured `*.exe` paths: tries the configured path, then an extension-less sibling binary (Linux/macOS convention in the same bundled folder), then `PATH`. Used for the Piper binary in `ltv_service.py` (3 call sites)
- **`app/utils/ffmpeg_utils.py: find_ffmpeg()`** - also accepts an extension-less bundled binary before falling back to system `PATH`
- **`app/core/audio_pipeline.py: _move_file()`** - fixes a real crash: `Path.replace()`/`os.replace()` raises `EXDEV (Invalid cross-device link)` when the temp dir and the output dir are on different filesystems. On Linux `/tmp` is typically tmpfs while output is on another mount, so **every** server-side generation job failed at the final export step. The helper uses `os.replace` with a `shutil.move` fallback.

## Test plan (all executed on Arch Linux, KDE/Wayland, Python 3.12)

- [x] App starts and the main window renders under Wayland
- [x] Piper runtime for Linux (piper 1.2.0, linux_x86_64) placed in `engines/piper/` is auto-detected via `resolve_executable` and reports `installed: true` in `/engines`
- [x] Russian Piper voice (`ru_RU-dmitri-medium`) synthesizes speech both via CLI and via the app engine
- [x] HTTP server (`engine_host.py`): `POST /jobs` with Piper + Russian voice now completes and produces `output/*.mp3` (before the fix it failed with EXDEV at 33% progress)
- [x] System ffmpeg (`/usr/bin/ffmpeg`) is found without any config changes

## Notes

- The auto-update flow stays Windows-only (it already guards with `sys.platform.startswith('win')`); Linux users update with `git pull` - documented in docs/LINUX.md
- No Windows behavior is changed: all new code paths only trigger when the `.exe` path is missing or `os.replace` raises
- Bundled Linux binaries (Piper runtime, voices) are intentionally NOT committed - `.gitignore` already covers them; Linux users download them via engine management or manually (documented)

Спасибо за отличный инструмент - happy to adjust anything to match the project's conventions.

## Update 2: private Python runtime on Linux (commit 85cb6ca)

Engine installation failed on Linux with `Permission denied: .../python.exe`: the runtime manager downloaded the **Windows** embeddable Python and tried to execute `python.exe`.

- On Linux/macOS the private runtime is now a **venv created from the system Python** (stdlib `venv` + core packages, no downloads)
- `python_exe` resolves to `bin/python`, `runtime_version` is platform-tagged, `pip_module_path` handles the `lib/python*/site-packages` layout
- Windows flow (embeddable zip + get-pip) is completely unchanged

Verified: `PythonRuntimeManager().install()` completes on Linux, `is_installed()` is True, and engine installation proceeds in the GUI.
